### PR TITLE
Remove OpenMP as a dependency.

### DIFF
--- a/python-package/packager/build_config.py
+++ b/python-package/packager/build_config.py
@@ -11,7 +11,7 @@ class BuildConfiguration:  # pylint: disable=R0902
     # Whether to hide C++ symbols in libxgboost.so
     hide_cxx_symbols: bool = True
     # Whether to enable OpenMP
-    use_openmp: bool = True
+    use_openmp: bool = False
     # Whether to enable CUDA
     use_cuda: bool = False
     # Whether to enable NCCL

--- a/python-package/pyproject.toml
+++ b/python-package/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "packager.pep517"
 
 [project]
 name = "xgboost"
-version = "2.1.0-dev"
+version = "2.1.0-dev2"
 authors = [
     { name = "Hyunsu Cho", email = "chohyu01@cs.washington.edu" },
     { name = "Jiaming Yuan", email = "jm.yuan@outlook.com" }


### PR DESCRIPTION
This commit removes OpenMP as a dependency -- this has to be done in the build configuration because configuration setting flags aren't supported for sdist builds.